### PR TITLE
Bump v0.2.2 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pod-runtime-class-policy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pod-runtime-class-policy"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.1
+version: 0.2.2
 name: pod-runtime
 displayName: Pod Runtime
-createdAt: 2023-05-08T13:07:00.327651974Z
+createdAt: 2023-07-07T18:57:47.267727872Z
 description: Policy that controls the usage of Pod runtimeClass
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/pod-runtime-class-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/pod-runtime:v0.2.1
+  image: ghcr.io/kubewarden/policies/pod-runtime:v0.2.2
 keywords:
 - pod
 - runtime
 - container runtime
 links:
 - name: policy
-  url: https://github.com/kubewarden/pod-runtime-class-policy/releases/download/v0.2.1/policy.wasm
+  url: https://github.com/kubewarden/pod-runtime-class-policy/releases/download/v0.2.2/policy.wasm
 - name: source
   url: https://github.com/kubewarden/pod-runtime-class-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/pod-runtime:v0.2.1
+  kwctl pull ghcr.io/kubewarden/policies/pod-runtime:v0.2.2
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.2.2 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.2.2

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
